### PR TITLE
update title from microblog to IDI Research Scraping Tool

### DIFF
--- a/flask_scraper_demo/app/templates/base.html
+++ b/flask_scraper_demo/app/templates/base.html
@@ -9,9 +9,9 @@
         <link rel= "stylesheet" type= "text/css" href= "{{ url_for('static',filename='css/styles/basic.css') }}">
 
         {% if title %}
-        <title>{{ title }} - microblog</title>
+        <title>{{ title }} - IDI Research Scraping Tool</title>
         {% else %}
-        <title>microblog</title>
+        <title>IDI Research Scraping Tool</title>
         {% endif %}
     </head>
     <body>


### PR DESCRIPTION
Resolves #46 . Is 'IDI Research Scraping Tool' a sufficiently better title than 'microblog'? @jimjshields @mdgis 