### PR TITLE
Add restriction to file upload for only Excel files

### DIFF
--- a/flask_scraper_demo/app/routes.py
+++ b/flask_scraper_demo/app/routes.py
@@ -10,9 +10,6 @@ from .scrapers.execute_search import execute_search, SELECT_ALL_NAME
 from .table_builder import TableBuilder
 
 
-
-
-
 @app.route('/')
 @app.route('/index')
 def index():
@@ -23,9 +20,11 @@ def index():
 def search_terms():
     if request.method == 'POST':
         f = request.files['file']
-
+        
+        # Assume we only have an .xls or .xlsx file - this is set on the html form.
         # clean input, remove space paddings, drop duplicates
         terms = pd.read_excel(f, header=None)[0].str.strip()
+
         duplicated_terms = [term for term in terms[terms.duplicated()]]
         if duplicated_terms:
             flash('{} term(s) were dropped for being duplicates: {}'.format(

--- a/flask_scraper_demo/app/templates/index.html
+++ b/flask_scraper_demo/app/templates/index.html
@@ -14,7 +14,12 @@
               <form action = "{{ url_for('search_terms') }}" method = "POST"
             style="width:100%"
          enctype = "multipart/form-data">
-         <input type = "file" class="btn btn-light" name = "file" />
+         <input
+            type ="file"
+            class="btn btn-light"
+            name ="file" 
+            accept="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel" 
+        />
          <input type = "submit" class="btn btn-dark" />
       </form>
 


### PR DESCRIPTION
This addresses https://github.com/datakind/idi-datadive-2018/issues/54 in a slightly different way — when you try to upload a file, it won't let you upload anything but .xls or .xlsx.